### PR TITLE
fix: include H2O, O2, and O3 in list of automatically subscripted chemicals

### DIFF
--- a/examples/sample-docs/projects/sample-guide/content/appendix.md
+++ b/examples/sample-docs/projects/sample-guide/content/appendix.md
@@ -8,6 +8,9 @@ The following chemical formulas should be subscripted automatically:
 * CO2
 * CF4
 * CH4
+* H2O
 * N2O
 * NF3
+* O2
+* O3
 * SF6

--- a/packages/docs-builder/src/gen-html.ts
+++ b/packages/docs-builder/src/gen-html.ts
@@ -551,8 +551,11 @@ const subscriptMap = new Map([
   ['CO2', 'CO<sub>2</sub>'],
   ['CF4', 'CF<sub>4</sub>'],
   ['CH4', 'CH<sub>4</sub>'],
+  ['H2O', 'H<sub>2</sub>O'],
   ['N2O', 'N<sub>2</sub>O'],
   ['NF3', 'NF<sub>3</sub>'],
+  ['O2', 'O<sub>2</sub>'],
+  ['O3', 'O<sub>3</sub>'],
   ['SF6', 'SF<sub>6</sub>']
 ])
 
@@ -563,8 +566,11 @@ const subscriptMap = new Map([
  *   CO2
  *   CF4
  *   CH4
+ *   H2O
  *   N2O
  *   NF3
+ *   O2
+ *   O3
  *   SF6
  *
  * @param s The input string.
@@ -574,7 +580,7 @@ function subscriptify(s: string): string {
   // XXX: Some historical graph images in the En-ROADS User Guide have
   // {CO2,CH4,N2O} in the file name, so this regex is set up to avoid
   // converting those filenames
-  return s.replace(/(Hist_)?(CO2|CF4|CH4|N2O|NF3|SF6)/g, (m, m1, m2) => {
+  return s.replace(/(Hist_)?(CO2|CF4|CH4|H2O|N2O|NF3|O2|O3|SF6)/g, (m, m1, m2) => {
     if (m1) {
       return m
     } else {


### PR DESCRIPTION
Fixes #53 
