### PR TITLE
fix: correct file watcher to ignore saved.md files instead of saved.json

### DIFF
--- a/packages/docs-builder/bin/cli.js
+++ b/packages/docs-builder/bin/cli.js
@@ -124,7 +124,7 @@ function watch() {
   const filesToWatch = [glob(projectsDir)]
   const watcher = chokidar.watch(filesToWatch, {
     ignoreInitial: true,
-    ignored: [/en\/docs\.po/, /saved\.json/, /timestamp/, /public/],
+    ignored: [/en\/docs\.po/, /saved\.md/, /timestamp/, /public/],
     // XXX: Include a delay, otherwise on macOS we sometimes get multiple
     // change events when a file is saved just once
     awaitWriteFinish: {


### PR DESCRIPTION
Fixes #68 
