### PR TITLE
fix: add endonym mapping for Czech language

### DIFF
--- a/packages/docs-builder/src/gen-html.ts
+++ b/packages/docs-builder/src/gen-html.ts
@@ -14,6 +14,7 @@ import type { HtmlPage, MarkdownPage } from './types'
 const langEndonyms: Map<string, string> = new Map([
   ['ar', 'العربية'],
   ['bg', 'Български'],
+  ['cs', 'Čeština'],
   ['de', 'Deutsch'],
   ['en', 'English'],
   ['es', 'Español'],


### PR DESCRIPTION
Fixes #77 
