### PR TITLE
fix: correct block ID regex so that an error is thrown when invalid characters are included

### DIFF
--- a/packages/docs-builder/src/parse.spec.ts
+++ b/packages/docs-builder/src/parse.spec.ts
@@ -182,6 +182,17 @@ Hello
     )
   })
 
+  it('should throw an error if a section command is used with an invalid identifier', () => {
+    const md = `\
+<!-- section:foo_50_%_bar -->
+Hello
+`
+    const enContext = new Context(config, 'en')
+    expect(() => parseMarkdownPageContent(enContext, 'page_1.md', md)).toThrow(
+      `Identifier (foo_50_%_bar) must contain only lowercase letters, digits, and underscores (page=page_1.md)`
+    )
+  })
+
   it('should throw an error if a begin-def command is not closed', () => {
     const md = `\
 <!-- begin-def:example_1 -->

--- a/packages/docs-builder/src/parse.ts
+++ b/packages/docs-builder/src/parse.ts
@@ -173,7 +173,11 @@ function parseCommand(context: Context, token: marked.Token): Command | undefine
     return undefined
   }
 
-  const m = raw.match(/<!--\s*([a-z-]+)(\[hidden\])?:?(\w+)?\s*-->/)
+  // Note: the identifier is captured as a run of non-whitespace characters (rather
+  // than `\w+`) so that an id containing invalid characters (e.g. `%`) is still
+  // captured here and caught by the validation below, instead of causing the whole
+  // match to fail and the command to be silently ignored
+  const m = raw.match(/<!--\s*([a-z-]+)(\[hidden\])?:?(\S+)?\s*-->/)
   if (!m) {
     return undefined
   }


### PR DESCRIPTION
Fixes #120 
